### PR TITLE
Allow API connection over HTTPS

### DIFF
--- a/APIHandler.py
+++ b/APIHandler.py
@@ -5,8 +5,9 @@ from resthandle import Request
 
 class APIHandler:
 
-    def __init__(self, ip):
-        self.url = "http://" + ip + "/cgi-bin/api.cgi"
+    def __init__(self, ip, https=False):
+        scheme = 'https' if https else 'http'
+        self.url = f"{scheme}://{ip}/cgi-bin/api.cgi"
         self.token = None
 
     # Token

--- a/Camera.py
+++ b/Camera.py
@@ -3,9 +3,10 @@ from APIHandler import APIHandler
 
 class Camera(APIHandler):
 
-    def __init__(self, ip, username="admin", password=""):
-        APIHandler.__init__(self, ip)
+    def __init__(self, ip, username="admin", password="", https=False):
+        APIHandler.__init__(self, ip, https=https)
         self.ip = ip
         self.username = username
         self.password = password
+        self.https = https
         super().login(self.username, self.password)

--- a/resthandle.py
+++ b/resthandle.py
@@ -17,9 +17,9 @@ class Request:
         try:
             headers = {'content-type': 'application/json'}
             if params is not None:
-                r = requests.post(url, params=params, json=data, headers=headers)
+                r = requests.post(url, verify=False, params=params, json=data, headers=headers)
             else:
-                r = requests.post(url, json=data)
+                r = requests.post(url, verify=False, json=data)
             if r.status_code == 200:
                 return r
             else:
@@ -38,7 +38,7 @@ class Request:
         :return:
         """
         try:
-            data = requests.get(url=url, params=params, timeout=timeout)
+            data = requests.get(url=url, verify=False, params=params, timeout=timeout)
             return data
         except Exception as e:
             print("Get Error\n", e)


### PR DESCRIPTION
This PR allows the API to connect to cameras over HTTPS. The `requests` calls in `resthandle.py` are required to not verify SSL certificates since the cameras' certificates are only self-signed (at least on current firmware).

Also, I was looking at implementing other APIs, particularly around zoom/focus.  Happy to accept PRs if I write some code for that?